### PR TITLE
Polishing and refactoring

### DIFF
--- a/lib/statsfl.dart
+++ b/lib/statsfl.dart
@@ -139,9 +139,7 @@ class _StatsFlState extends State<StatsFl> {
                     ),
                   ),
                 ),
-              )
-            else
-              Container()
+              ),
           ],
         ),
       ),

--- a/lib/statsfl.dart
+++ b/lib/statsfl.dart
@@ -96,7 +96,7 @@ class _StatsFlState extends State<StatsFl> {
     super.dispose();
   }
 
-    void _handleTick(Duration d) {
+  void _handleTick(Duration d) {
     if (!widget.isEnabled) {
       _lastCalcTime = nowMs;
       return;
@@ -111,7 +111,6 @@ class _StatsFlState extends State<StatsFl> {
       _fps = min((_ticks * 1000 / sampleTimeMs).roundToDouble(), widget.maxFps.toDouble());
       _ticks = 0;
       //Add new entry, remove old ones
-
       _entries.value.add(_FpsEntry(_lastCalcTime, _fps));
       _entries.value = List.from(_entries.value)..removeWhere((e) => nowMs - e.time > totalTimeMs);
     }

--- a/lib/statsfl.dart
+++ b/lib/statsfl.dart
@@ -190,8 +190,7 @@ class _StatsPainter extends CustomPainter {
 
   _StatsPainter({this.state});
 
-  double getYForFps(double fps, double maxHeight) =>
-      maxHeight - 2 - (min((fps / 60), 1) * (maxHeight - topPadding));
+  double getYForFps(double fps, double maxHeight) => maxHeight - 2 - (min((fps / 60), 1) * (maxHeight - topPadding));
 
   @override
   void paint(Canvas canvas, Size size) {

--- a/lib/statsfl.dart
+++ b/lib/statsfl.dart
@@ -75,9 +75,18 @@ class _StatsFlState extends State<StatsFl> {
   void initState() {
     _fps = widget.maxFps.toDouble();
     _ticker = Ticker(_handleTick);
-    _ticker.start();
     _lastCalcTime = nowMs;
     super.initState();
+  }
+
+  @override
+  void didUpdateWidget(StatsFl oldWidget) {
+    if (widget.isEnabled) {
+      _ticker.start();
+    } else {
+      _ticker.stop();
+    }
+    super.didUpdateWidget(oldWidget);
   }
 
   @override

--- a/lib/statsfl.dart
+++ b/lib/statsfl.dart
@@ -49,6 +49,7 @@ class StatsFl extends StatefulWidget {
     assert((showText != true || height >= 30), "If showText=true, height must be at least 30px");
     assert((height >= 8), "height must be >= 8px");
     assert(child != null, "child can't be null.");
+    assert(isEnabled != null, "isEnabled can't be null.");
   }
 
   @override

--- a/lib/statsfl.dart
+++ b/lib/statsfl.dart
@@ -81,11 +81,12 @@ class _StatsFlState extends State<StatsFl> {
 
   @override
   void didUpdateWidget(StatsFl oldWidget) {
-    if (widget.isEnabled) {
-      _ticker.start();
-    } else {
-      _ticker.stop();
+    final currentEnabledStatus = widget.isEnabled;
+
+    if (oldWidget.isEnabled != currentEnabledStatus) {
+      currentEnabledStatus ? _ticker.start() : _ticker.stop();
     }
+
     super.didUpdateWidget(oldWidget);
   }
 

--- a/lib/statsfl.dart
+++ b/lib/statsfl.dart
@@ -150,10 +150,8 @@ class _StatsFlState extends State<StatsFl> with SingleTickerProviderStateMixin {
     String fToString(double value) => value.toStringAsPrecision(2);
     double minFps = 0, maxFps = 0;
     if (_entries.isNotEmpty) {
-      minFps =
-          _entries.reduce((prev, e) => e.fps < prev.fps ? e : prev)?.fps ?? 0;
-      maxFps =
-          _entries.reduce((prev, e) => e.fps > prev.fps ? e : prev)?.fps ?? 0;
+      minFps = _entries.reduce((prev, e) => e.fps < prev.fps ? e : prev)?.fps ?? 0;
+      maxFps = _entries.reduce((prev, e) => e.fps > prev.fps ? e : prev)?.fps ?? 0;
     }
     double lastFps = _entries.isNotEmpty ? _entries.last.fps : 60;
     return CustomPaint(
@@ -164,10 +162,7 @@ class _StatsFlState extends State<StatsFl> with SingleTickerProviderStateMixin {
           child: widget.showText
               ? Text(
                   "${fToString(_fps)} FPS (${fToString(minFps)}-${fToString(maxFps)})",
-                  style: TextStyle(
-                      color: _getColorForFps(lastFps),
-                      fontWeight: FontWeight.bold,
-                      fontSize: 11),
+                  style: TextStyle(color: _getColorForFps(lastFps), fontWeight: FontWeight.bold, fontSize: 11),
                 )
               : Container(),
         ));
@@ -205,15 +200,10 @@ class _StatsPainter extends CustomPainter {
     double colWidth = size.width / (maxXAxis / state.sampleTimeMs);
     for (var e in state._entries) {
       Color c = state._getColorForFps(e.fps);
-      double x = size.width -
-          colWidth -
-          ((state.nowMs - e.time) / maxXAxis) * size.width;
+      double x = size.width - colWidth - ((state.nowMs - e.time) / maxXAxis) * size.width;
       double y = getYForFps(e.fps, size.height);
-      canvas.drawRect(
-          Rect.fromLTWH(x, y, colWidth + .5, 2), Paint()..color = c);
-      canvas.drawRect(
-          Rect.fromLTWH(x, y + 3, colWidth + .5, size.height - y - 2),
-          Paint()..color = c.withOpacity(.2));
+      canvas.drawRect(Rect.fromLTWH(x, y, colWidth + .5, 2), Paint()..color = c);
+      canvas.drawRect(Rect.fromLTWH(x, y + 3, colWidth + .5, size.height - y - 2), Paint()..color = c.withOpacity(.2));
     }
   }
 

--- a/lib/statsfl.dart
+++ b/lib/statsfl.dart
@@ -81,10 +81,10 @@ class _StatsFlState extends State<StatsFl> {
 
   @override
   void didUpdateWidget(StatsFl oldWidget) {
-    final currentEnabledStatus = widget.isEnabled;
+    final isEnabled = widget.isEnabled;
 
-    if (oldWidget.isEnabled != currentEnabledStatus) {
-      currentEnabledStatus ? _ticker.start() : _ticker.stop();
+    if (oldWidget.isEnabled != isEnabled) {
+      isEnabled ? _ticker.start() : _ticker.stop();
     }
 
     super.didUpdateWidget(oldWidget);


### PR DESCRIPTION
Hi @esDotDev @gskinner, thanks for your awesome plugin!

We used it on our project and it works very well, but we noticed some slight things that could potentially be improved:

1. Migrate from ChangeNotifier to ValueNotifier as State<StatsFl> and ChangeNotifier both have dispose() so we are getting into this issue https://github.com/flutter/flutter/issues/24293 
2. Moving isEnabled a bit down as we wanted to place FPS monitor above MaterialApp. If we pass MaterialApp as FPS monitor child - FPS monitor is displayed under dialog background - which we don't want to have, otherwise is FPS monitor over MaterialApp on isEnabled it messes up with the navigator.
3. As we implemented FPS monitor visibility toggle guys wanted to make sure that the ticker stops/starts on isEnabled update.

Let me know what you think or if we missed something.
Thanks,
Illia
