### PR TITLE
FIX: fps value format support 120hz

### DIFF
--- a/lib/statsfl.dart
+++ b/lib/statsfl.dart
@@ -147,7 +147,7 @@ class _StatsFlState extends State<StatsFl> {
   }
 
   Widget _buildPainter(List<_FpsEntry> entries) {
-    String fToString(double value) => value.toStringAsPrecision(2);
+    String fToString(double value) => value.toStringAsPrecision(3);
     double minFps = 0, maxFps = 0;
     if (entries.isNotEmpty) {
       minFps = entries.reduce((prev, e) => e.fps < prev.fps ? e : prev).fps;


### PR DESCRIPTION
The default format method is `double.toStringAsPrecision(2)` , but when the device max fps is 120hz, the display value will  like `1.2e+2`

<img width="381" alt="image" src="https://user-images.githubusercontent.com/44760239/161892457-784fd475-27c6-4815-a006-7c9eb3fb8dab.png">

The finally display result:
<img width="362" alt="image" src="https://user-images.githubusercontent.com/44760239/161892482-a47ce41d-5dc1-4e91-b88a-8ac145fef4b5.png">
